### PR TITLE
doc: iifeフォーマット出力時にはentryFileNamesオプションが必要

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ export default defineConfig([
     output: [
       {
         format: 'iife',
-        target: 'es2020',
-        file: './dist/main.js',
+        name: '_',
+        entryFileNames: '[name].js',
+        minify: false,
       },
     ],
     plugins: [gasPlugin()],


### PR DESCRIPTION
minify有効時はエラーが発生しやすいため、無効を推奨